### PR TITLE
Update TaskBook methods and add tests

### DIFF
--- a/src/main/java/taskbook/model/TaskBook.java
+++ b/src/main/java/taskbook/model/TaskBook.java
@@ -3,6 +3,7 @@ package taskbook.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Objects;
 
 import javafx.collections.ObservableList;
 import taskbook.model.person.Name;

--- a/src/main/java/taskbook/model/TaskBook.java
+++ b/src/main/java/taskbook/model/TaskBook.java
@@ -173,11 +173,12 @@ public class TaskBook implements ReadOnlyTaskBook {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof TaskBook // instanceof handles nulls
-                && persons.equals(((TaskBook) other).persons));
+                && persons.equals(((TaskBook) other).persons)
+                && tasks.equals(((TaskBook) other).tasks));
     }
 
     @Override
     public int hashCode() {
-        return persons.hashCode();
+        return Objects.hash(persons, tasks);
     }
 }

--- a/src/test/data/JsonSerializableTaskBookTest/typicalPersonsTaskBook.json
+++ b/src/test/data/JsonSerializableTaskBookTest/typicalPersonsTaskBook.json
@@ -43,5 +43,24 @@
     "address" : "4th street",
     "tagged" : [ ]
   } ],
-  "tasks": []
+  "tasks": [
+    {
+      "name" : "Alice Pauline",
+      "assignment" : "TO",
+      "description" : "eat fruit",
+      "isDone" : true
+    },
+    {
+      "name" : "Benson Meier",
+      "assignment" : "FROM",
+      "description" : "sleep early",
+      "isDone" : false
+    },
+    {
+      "name" : "Carl Kurz",
+      "assignment" : "TO",
+      "description" : "party at kevin's house",
+      "isDone" : true
+    }
+  ]
 }

--- a/src/test/java/taskbook/model/TaskBookTest.java
+++ b/src/test/java/taskbook/model/TaskBookTest.java
@@ -37,7 +37,7 @@ public class TaskBookTest {
     }
 
     @Test
-    public void resetData_withValidReadOnlytaskBook_replacesData() {
+    public void resetData_withValidReadOnlyTaskBook_replacesData() {
         TaskBook newData = TypicalTaskBook.getTypicalTaskBook();
         taskBook.resetData(newData);
         assertEquals(newData, taskBook);
@@ -47,8 +47,8 @@ public class TaskBookTest {
     public void resetData_withDuplicatePersons_throwsDuplicatePersonException() {
         // Two persons with the same identity fields
         Person editedAlice = new PersonBuilder(TypicalTaskBook.ALICE)
-                .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
-                .build();
+            .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+            .build();
         List<Person> newPersons = Arrays.asList(TypicalTaskBook.ALICE, editedAlice);
         TaskBookStub newData = new TaskBookStub(newPersons);
 
@@ -61,28 +61,33 @@ public class TaskBookTest {
     }
 
     @Test
-    public void hasPerson_personNotIntaskBook_returnsFalse() {
+    public void hasPerson_personNotInTaskBook_returnsFalse() {
         assertFalse(taskBook.hasPerson(TypicalTaskBook.ALICE));
     }
 
     @Test
-    public void hasPerson_personIntaskBook_returnsTrue() {
+    public void hasPerson_personInTaskBook_returnsTrue() {
         taskBook.addPerson(TypicalTaskBook.ALICE);
         assertTrue(taskBook.hasPerson(TypicalTaskBook.ALICE));
     }
 
     @Test
-    public void hasPerson_personWithSameIdentityFieldsIntaskBook_returnsTrue() {
+    public void hasPerson_personWithSameIdentityFieldsInTaskBook_returnsTrue() {
         taskBook.addPerson(TypicalTaskBook.ALICE);
         Person editedAlice = new PersonBuilder(TypicalTaskBook.ALICE)
-                .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
-                .build();
+            .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+            .build();
         assertTrue(taskBook.hasPerson(editedAlice));
     }
 
     @Test
     public void getPersonList_modifyList_throwsUnsupportedOperationException() {
         Assert.assertThrows(UnsupportedOperationException.class, () -> taskBook.getPersonList().remove(0));
+    }
+
+    @Test
+    public void getTaskList_modifyList_throwsUnsupportedOperationException() {
+        Assert.assertThrows(UnsupportedOperationException.class, () -> taskBook.getTaskList().remove(0));
     }
 
     /**

--- a/src/test/java/taskbook/storage/JsonSerializableTaskBookTest.java
+++ b/src/test/java/taskbook/storage/JsonSerializableTaskBookTest.java
@@ -26,8 +26,8 @@ public class JsonSerializableTaskBookTest {
         JsonSerializableTaskBook dataFromFile = JsonUtil.readJsonFile(TYPICAL_PERSONS_FILE,
                 JsonSerializableTaskBook.class).get();
         TaskBook taskBookFromFile = dataFromFile.toModelType();
-        TaskBook typicalPersonstaskBook = TypicalTaskBook.getTypicalTaskBook();
-        assertEquals(taskBookFromFile, typicalPersonstaskBook);
+        TaskBook typicalPersonsTaskBook = TypicalTaskBook.getTypicalTaskBook();
+        assertEquals(taskBookFromFile, typicalPersonsTaskBook);
     }
 
     @Test


### PR DESCRIPTION
1. Update TaskBook's `equals` and `hashCode` methods to use both `persons` and `tasks` lists.
1. Update `typicalPersonsTaskBook.json` to have typical tasks.
1. Added a few small tests.
1. Fix casing.