### PR TITLE
Add shortcut to category words contact and task

### DIFF
--- a/src/main/java/taskbook/logic/parser/TaskBookParser.java
+++ b/src/main/java/taskbook/logic/parser/TaskBookParser.java
@@ -22,7 +22,9 @@ public class TaskBookParser {
      */
     private static final String CATEGORIES = String.join("|",
         ContactCategoryParser.CATEGORY_WORD,
-        TaskCategoryParser.CATEGORY_WORD
+        ContactCategoryParser.CATEGORY_WORD_SHORTCUT,
+        TaskCategoryParser.CATEGORY_WORD,
+        TaskCategoryParser.CATEGORY_WORD_SHORTCUT
     );
     private static final String BASIC_COMMAND_REGEX =
         String.format("(?:(?<category>%s)\\s)?(?<commandWord>\\S+)(?<arguments>.*)", CATEGORIES);
@@ -50,9 +52,11 @@ public class TaskBookParser {
 
         if (category == null) {
             return CategorylessParser.parseCommand(commandWord, arguments);
-        } else if (category.equals(ContactCategoryParser.CATEGORY_WORD)) {
+        } else if (category.equals(ContactCategoryParser.CATEGORY_WORD)
+                || category.equals(ContactCategoryParser.CATEGORY_WORD_SHORTCUT)) {
             return ContactCategoryParser.parseCommand(commandWord, arguments);
-        } else if (category.equals(TaskCategoryParser.CATEGORY_WORD)) {
+        } else if (category.equals(TaskCategoryParser.CATEGORY_WORD)
+                || category.equals(TaskCategoryParser.CATEGORY_WORD_SHORTCUT)) {
             return TaskCategoryParser.parseCommand(commandWord, arguments);
         }
 

--- a/src/main/java/taskbook/logic/parser/contacts/ContactCategoryParser.java
+++ b/src/main/java/taskbook/logic/parser/contacts/ContactCategoryParser.java
@@ -13,6 +13,7 @@ import taskbook.logic.parser.exceptions.ParseException;
  */
 public class ContactCategoryParser {
     public static final String CATEGORY_WORD = "contact";
+    public static final String CATEGORY_WORD_SHORTCUT = "c";
 
     /**
      * Parses user input into command for execution.

--- a/src/main/java/taskbook/logic/parser/tasks/TaskCategoryParser.java
+++ b/src/main/java/taskbook/logic/parser/tasks/TaskCategoryParser.java
@@ -18,6 +18,7 @@ import taskbook.logic.parser.exceptions.ParseException;
  */
 public class TaskCategoryParser {
     public static final String CATEGORY_WORD = "task";
+    public static final String CATEGORY_WORD_SHORTCUT = "t";
 
     /**
      * Parses user input into command for execution.

--- a/src/main/java/taskbook/logic/parser/tasks/TaskSortCommandParser.java
+++ b/src/main/java/taskbook/logic/parser/tasks/TaskSortCommandParser.java
@@ -79,4 +79,3 @@ public class TaskSortCommandParser implements Parser<TaskSortCommand> {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }
-}

--- a/src/test/java/taskbook/logic/parser/TaskBookParserTest.java
+++ b/src/test/java/taskbook/logic/parser/TaskBookParserTest.java
@@ -98,17 +98,17 @@ public class TaskBookParserTest {
     }
 
     @Test
-<<<<<<< HEAD
     public void parseCommand_taskShortcut_list() throws Exception {
         assertTrue(parseTaskCommandShortcut(TaskListCommand.COMMAND_WORD) instanceof TaskListCommand);
         assertTrue(parseTaskCommandShortcut(TaskListCommand.COMMAND_WORD + " 3") instanceof TaskListCommand);
-=======
+    }
+
+    @Test
     public void parseCommand_task_sort() throws Exception {
         assertTrue(parseTaskCommand(TaskSortCommand.COMMAND_WORD + " s/a")
                 instanceof TaskSortDescriptionAlphabeticalCommand);
         assertTrue(parseTaskCommand(TaskSortCommand.COMMAND_WORD + " s/ca")
                 instanceof TaskSortAddedChronologicalCommand);
->>>>>>> 228680f4a34db60f56a991709fb426ee696b85fd
     }
 
     @Test

--- a/src/test/java/taskbook/logic/parser/TaskBookParserTest.java
+++ b/src/test/java/taskbook/logic/parser/TaskBookParserTest.java
@@ -53,6 +53,12 @@ public class TaskBookParserTest {
     }
 
     @Test
+    public void parseCommand_contactShortcut_list() throws Exception {
+        assertTrue(parseContactCommandShortcut(ContactListCommand.COMMAND_WORD) instanceof ContactListCommand);
+        assertTrue(parseContactCommandShortcut(ContactListCommand.COMMAND_WORD + " 3") instanceof ContactListCommand);
+    }
+
+    @Test
     public void parseCommand_task_todo() throws Exception {
         TaskTodoCommand command = (TaskTodoCommand) parseTaskCommand("todo m/John d/Finish user guide");
         assertNotNull(command);
@@ -89,6 +95,12 @@ public class TaskBookParserTest {
     }
 
     @Test
+    public void parseCommand_taskShortcut_list() throws Exception {
+        assertTrue(parseTaskCommandShortcut(TaskListCommand.COMMAND_WORD) instanceof TaskListCommand);
+        assertTrue(parseTaskCommandShortcut(TaskListCommand.COMMAND_WORD + " 3") instanceof TaskListCommand);
+    }
+
+    @Test
     public void parseCommand_exit() throws Exception {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
@@ -115,7 +127,15 @@ public class TaskBookParserTest {
         return parseCommandWithCategory(ContactCategoryParser.CATEGORY_WORD, command);
     }
 
+    private Command parseContactCommandShortcut(String command) throws ParseException {
+        return parseCommandWithCategory(ContactCategoryParser.CATEGORY_WORD_SHORTCUT, command);
+    }
+
     private Command parseTaskCommand(String command) throws ParseException {
         return parseCommandWithCategory(TaskCategoryParser.CATEGORY_WORD, command);
+    }
+
+    private Command parseTaskCommandShortcut(String command) throws ParseException {
+        return parseCommandWithCategory(TaskCategoryParser.CATEGORY_WORD_SHORTCUT, command);
     }
 }


### PR DESCRIPTION
Commands can now use t and c instead of task and contact
Fixes #128