### PR TITLE
Fix edit commands

### DIFF
--- a/src/main/java/taskbook/logic/commands/contacts/ContactEditCommand.java
+++ b/src/main/java/taskbook/logic/commands/contacts/ContactEditCommand.java
@@ -20,6 +20,7 @@ import taskbook.commons.util.CollectionUtil;
 import taskbook.logic.commands.Command;
 import taskbook.logic.commands.CommandResult;
 import taskbook.logic.commands.exceptions.CommandException;
+import taskbook.logic.parser.contacts.ContactCategoryParser;
 import taskbook.model.Model;
 import taskbook.model.person.Address;
 import taskbook.model.person.Email;
@@ -45,7 +46,7 @@ public class ContactEditCommand extends Command {
         + "[" + PREFIX_EMAIL + "EMAIL] "
         + "[" + PREFIX_ADDRESS + "ADDRESS] "
         + "[" + PREFIX_TAG + "TAG]...\n"
-        + "Example: " + COMMAND_WORD + " " + PREFIX_INDEX + " 1 "
+        + "Example: " + ContactCategoryParser.CATEGORY_WORD + " " + COMMAND_WORD + " " + PREFIX_INDEX + " 1 "
         + PREFIX_PHONE + "91234567 "
         + PREFIX_EMAIL + "johndoe@example.com";
 

--- a/src/main/java/taskbook/logic/commands/tasks/TaskEditCommand.java
+++ b/src/main/java/taskbook/logic/commands/tasks/TaskEditCommand.java
@@ -16,6 +16,7 @@ import taskbook.commons.core.index.Index;
 import taskbook.logic.commands.Command;
 import taskbook.logic.commands.CommandResult;
 import taskbook.logic.commands.exceptions.CommandException;
+import taskbook.logic.parser.tasks.TaskCategoryParser;
 import taskbook.model.Model;
 import taskbook.model.person.Person;
 import taskbook.model.task.EditTaskDescriptor;
@@ -37,7 +38,7 @@ public class TaskEditCommand extends Command {
         + "[" + PREFIX_DESCRIPTION + "DESCRIPTION] "
         + "[" + PREFIX_DATE + "DATE] "
         + "[" + PREFIX_TAG + "TAG]...\n"
-        + "Example: " + COMMAND_WORD + " " + PREFIX_INDEX + " 1 "
+        + "Example: " + TaskCategoryParser.CATEGORY_WORD + " " + COMMAND_WORD + " " + PREFIX_INDEX + " 1 "
         + PREFIX_ASSIGN_FROM + "Jackie Chan "
         + PREFIX_DESCRIPTION + "Practice kick 10000 times";
 

--- a/src/main/java/taskbook/logic/parser/contacts/ContactEditCommandParser.java
+++ b/src/main/java/taskbook/logic/parser/contacts/ContactEditCommandParser.java
@@ -44,15 +44,7 @@ public class ContactEditCommandParser implements Parser<ContactEditCommand> {
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, ContactEditCommand.MESSAGE_USAGE));
         }
 
-        String stringIndex = argMultimap.getValue(PREFIX_INDEX).get();
-        Index index;
-        try {
-            int integerIndex = Integer.parseInt(stringIndex);
-            index = Index.fromOneBased(integerIndex);
-        } catch (NumberFormatException ne) {
-            throw new ParseException(
-                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, ContactEditCommand.MESSAGE_USAGE), ne);
-        }
+        Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INDEX).get());
 
         ContactEditCommand.EditPersonDescriptor editPersonDescriptor = new ContactEditCommand.EditPersonDescriptor();
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {

--- a/src/main/java/taskbook/logic/parser/tasks/TaskEditCommandParser.java
+++ b/src/main/java/taskbook/logic/parser/tasks/TaskEditCommandParser.java
@@ -47,15 +47,7 @@ public class TaskEditCommandParser implements Parser<TaskEditCommand> {
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, TaskEditCommand.MESSAGE_USAGE));
         }
 
-        String stringIndex = argMultimap.getValue(PREFIX_INDEX).get();
-        Index index;
-        try {
-            int integerIndex = Integer.parseInt(stringIndex);
-            index = Index.fromOneBased(integerIndex);
-        } catch (NumberFormatException ne) {
-            throw new ParseException(
-                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, TaskEditCommand.MESSAGE_USAGE), ne);
-        }
+        Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INDEX).get());
 
         EditTaskDescriptor editTaskDescriptor = new EditTaskDescriptor();
 

--- a/src/main/java/taskbook/model/task/Todo.java
+++ b/src/main/java/taskbook/model/task/Todo.java
@@ -18,7 +18,8 @@ import taskbook.model.task.enums.Assignment;
  */
 public class Todo extends Task {
 
-    private static final String PARAMETER_DATE = PREFIX_DATE + " DATE";
+    private static final String INVALID_PARAMETER_DATE =
+        String.format(MESSAGE_INVALID_PARAMETER, PREFIX_DATE + "DATE" + " (Todo does not have a date)");
 
     /**
      * Every field must be present and not null.
@@ -81,7 +82,7 @@ public class Todo extends Task {
     @Override
     public Todo createEditedCopy(EditTaskDescriptor descriptor) throws CommandException {
         if (descriptor.getDate().isPresent()) {
-            throw new CommandException(String.format(MESSAGE_INVALID_PARAMETER, PARAMETER_DATE));
+            throw new CommandException(INVALID_PARAMETER_DATE);
         }
 
         Name name = descriptor.getName().orElse(getName());

--- a/src/test/java/taskbook/logic/parser/ContactEditCommandParserTest.java
+++ b/src/test/java/taskbook/logic/parser/ContactEditCommandParserTest.java
@@ -42,18 +42,15 @@ public class ContactEditCommandParserTest {
     public void parse_invalidPreamble_failure() {
         // negative index
         CommandParserTestUtil.assertParseFailure(parser,
-                " i/-5" + CommandTestUtil.NAME_DESC_AMY,
-            MESSAGE_INVALID_INDEX);
+                " i/-5" + CommandTestUtil.NAME_DESC_AMY, MESSAGE_INVALID_INDEX);
 
         // zero index
         CommandParserTestUtil.assertParseFailure(parser,
-                " i/0" + CommandTestUtil.NAME_DESC_AMY,
-            MESSAGE_INVALID_INDEX);
+                " i/0" + CommandTestUtil.NAME_DESC_AMY, MESSAGE_INVALID_INDEX);
 
         // invalid arguments being parsed as preamble
         CommandParserTestUtil.assertParseFailure(parser,
-                "1 some random string",
-            MESSAGE_INVALID_FORMAT);
+                "1 some random string", MESSAGE_INVALID_FORMAT);
 
         // invalid prefix being parsed as preamble
         CommandParserTestUtil.assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_INDEX);
@@ -62,25 +59,15 @@ public class ContactEditCommandParserTest {
     @Test
     public void parse_invalidValue_failure() {
         CommandParserTestUtil.assertParseFailure(parser,
-                " i/1" + CommandTestUtil.INVALID_NAME_DESC,
-
-                Name.MESSAGE_CONSTRAINTS); // invalid name
+                " i/1" + CommandTestUtil.INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
         CommandParserTestUtil.assertParseFailure(parser,
-                " i/1" + CommandTestUtil.INVALID_PHONE_DESC,
-
-                Phone.MESSAGE_CONSTRAINTS); // invalid phone
+                " i/1" + CommandTestUtil.INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
         CommandParserTestUtil.assertParseFailure(parser,
-                " i/1" + CommandTestUtil.INVALID_EMAIL_DESC,
-
-                Email.MESSAGE_CONSTRAINTS); // invalid email
+                " i/1" + CommandTestUtil.INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
         CommandParserTestUtil.assertParseFailure(parser,
-                " i/1" + CommandTestUtil.INVALID_ADDRESS_DESC,
-
-                Address.MESSAGE_CONSTRAINTS); // invalid address
+                " i/1" + CommandTestUtil.INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
         CommandParserTestUtil.assertParseFailure(parser,
-                " i/1" + CommandTestUtil.INVALID_TAG_DESC,
-
-                Tag.MESSAGE_CONSTRAINTS); // invalid tag
+                " i/1" + CommandTestUtil.INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
 
         // invalid phone followed by valid email
         CommandParserTestUtil.assertParseFailure(parser,

--- a/src/test/java/taskbook/logic/parser/ContactEditCommandParserTest.java
+++ b/src/test/java/taskbook/logic/parser/ContactEditCommandParserTest.java
@@ -1,5 +1,7 @@
 package taskbook.logic.parser;
 
+import static taskbook.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
+
 import org.junit.jupiter.api.Test;
 
 import taskbook.commons.core.Messages;
@@ -40,21 +42,21 @@ public class ContactEditCommandParserTest {
     public void parse_invalidPreamble_failure() {
         // negative index
         CommandParserTestUtil.assertParseFailure(parser,
-                "-5" + CommandTestUtil.NAME_DESC_AMY,
-                MESSAGE_INVALID_FORMAT);
+                " i/-5" + CommandTestUtil.NAME_DESC_AMY,
+            MESSAGE_INVALID_INDEX);
 
         // zero index
         CommandParserTestUtil.assertParseFailure(parser,
-                "0" + CommandTestUtil.NAME_DESC_AMY,
-                MESSAGE_INVALID_FORMAT);
+                " i/0" + CommandTestUtil.NAME_DESC_AMY,
+            MESSAGE_INVALID_INDEX);
 
         // invalid arguments being parsed as preamble
         CommandParserTestUtil.assertParseFailure(parser,
                 "1 some random string",
-                MESSAGE_INVALID_FORMAT);
+            MESSAGE_INVALID_FORMAT);
 
         // invalid prefix being parsed as preamble
-        CommandParserTestUtil.assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+        CommandParserTestUtil.assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_INDEX);
     }
 
     @Test

--- a/src/test/java/taskbook/logic/parser/tasks/TaskEditCommandParserTest.java
+++ b/src/test/java/taskbook/logic/parser/tasks/TaskEditCommandParserTest.java
@@ -17,6 +17,7 @@ import static taskbook.logic.commands.tasks.TaskEditCommand.MESSAGE_ASSIGNOR_ASS
 import static taskbook.logic.commands.tasks.TaskEditCommand.MESSAGE_NOT_EDITED;
 import static taskbook.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static taskbook.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static taskbook.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 
 import org.junit.jupiter.api.Test;
 
@@ -121,6 +122,11 @@ public class TaskEditCommandParserTest {
             .build();
         expectedCommand = new TaskEditCommand(index, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_negativeIndex_throwsException() {
+        assertParseFailure(parser, " i/-5", MESSAGE_INVALID_INDEX);
     }
 
     private String indexAsInput(Index index) {


### PR DESCRIPTION
Fixes #214

I have also checked other similar commands, both `delete`s, `mark/unmark` and they do not have the same bug.

Fixes #220

Fixes #224 

Updated error message to be the following:
```
Invalid parameter: t/DATE (Todo does not have a date).
```